### PR TITLE
Add PHP 8.4 support and require PHP 8.3+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        php-versions: ['8.2','8.3']
+        php-versions: ['8.3', '8.4']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "assoconnect/php-quality-config": "^1.16"
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "symfony/framework-bundle": "^5.0|^6.0|^7.0",
         "symfony/serializer": "^5.1.8|^6.0|^7.0",
         "beberlei/assert": "^3.2.7"


### PR DESCRIPTION
## Summary
- Update minimum PHP requirement to 8.3
- Add PHP 8.4 to CI test matrix
- Align with php-template standards

## Changes
- Update composer.json to require PHP ^8.3
- Update GitHub Actions workflow to test on PHP 8.3 and 8.4
- Remove PHP 8.2 from test matrix

## Related
Part of organization-wide upgrade to standardize on PHP 8.3+ across all packages.

## Test plan
- [ ] CI tests pass on PHP 8.3
- [ ] CI tests pass on PHP 8.4
- [ ] All dependency version combinations tested (lowest/highest)