### PR TITLE
Remove support for Symfony 6 and lower

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,13 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.3', '8.4']
+        dependency-versions: ['lowest', 'highest']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       
@@ -22,8 +24,10 @@ jobs:
           php-version: ${{ matrix.php-versions }}
       
       - run: composer validate --strict
-      - run: composer config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
-      - run: composer install --prefer-dist --no-progress --no-suggest
+
+      - uses: ramsey/composer-install@v2
+        with:
+          dependency-versions: ${{ matrix.dependency-versions }}
 
       - run: vendor/bin/phpcs
         if: ${{ failure() ||  success() }}
@@ -53,5 +57,5 @@ jobs:
             -Dsonar.organization=assoconnect
             -Dsonar.sources=src
             -Dsonar.tests=tests
-            -Dsonar.php.coverage.reportPaths=./clover.xml
-            -Dsonar.php.tests.reportPath=./phpunit.report.xml
+            -Dsonar.php.coverage.reportPaths=clover.xml
+            -Dsonar.php.tests.reportPath=phpunit.report.xml

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     },
     "require": {
         "php": "^8.3",
-        "symfony/framework-bundle": "^5.0|^6.0|^7.0",
-        "symfony/serializer": "^5.1.8|^6.0|^7.0",
+        "symfony/framework-bundle": "^7.0",
+        "symfony/serializer": "^7.0",
         "beberlei/assert": "^3.2.7"
     },
     "config": {


### PR DESCRIPTION
## Summary
- Update symfony/framework-bundle and symfony/serializer constraints to require ^7.0 only
- Drop support for Symfony 5.x and 6.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)