### PR TITLE
Improves AbsolutePercentValue normalizer

### DIFF
--- a/src/Normalizer/AbsolutePercentValueNormalizer.php
+++ b/src/Normalizer/AbsolutePercentValueNormalizer.php
@@ -6,9 +6,10 @@ namespace AssoConnect\AbsolutePercentValueBundle\Normalizer;
 
 use AssoConnect\AbsolutePercentValueBundle\Object\AbsolutePercentValue;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
-use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Throwable;
 
 /**
  * Normalizes an instance of {@see AbsolutePercentValue} to an array ['type' => ..., 'value' => ...].
@@ -17,14 +18,14 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 class AbsolutePercentValueNormalizer implements NormalizerInterface, DenormalizerInterface
 {
     /**
-     * @param mixed $object
+     * @param mixed $data
      * @param mixed[] $context
      * @return mixed[]
      * @throws InvalidArgumentException
      */
-    public function normalize(mixed $object, ?string $format = null, array $context = []): array
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array
     {
-        if (!$object instanceof AbsolutePercentValue) {
+        if (!$data instanceof AbsolutePercentValue) {
             throw new InvalidArgumentException(sprintf(
                 'The object must be an instance of "%s".',
                 AbsolutePercentValue::class
@@ -32,8 +33,8 @@ class AbsolutePercentValueNormalizer implements NormalizerInterface, Denormalize
         }
 
         return [
-            'type' => $object->getType(),
-            'value' => $object->getValue()
+            'type' => $data->getType(),
+            'value' => $data->getValue()
         ];
     }
 
@@ -47,21 +48,22 @@ class AbsolutePercentValueNormalizer implements NormalizerInterface, Denormalize
     }
 
     /**
-     * @throws NotNormalizableValueException
+     * @inheritDoc
      */
     public function denormalize(
         mixed $data,
         string $type,
         ?string $format = null,
         array $context = []
-    ): mixed {
+    ): AbsolutePercentValue {
+        if ('' === $data || null === $data) {
+            throw new UnexpectedValueException();
+        }
+
         try {
-            if ('' === $data || null === $data) {
-                throw new NotNormalizableValueException();
-            }
             return new AbsolutePercentValue($data['type'], $data['value']);
-        } catch (\Exception $e) {
-            throw new NotNormalizableValueException($e->getMessage(), $e->getCode(), $e);
+        } catch (Throwable $e) {
+            throw new UnexpectedValueException(previous: $e);
         }
     }
 
@@ -83,6 +85,6 @@ class AbsolutePercentValueNormalizer implements NormalizerInterface, Denormalize
      */
     public function getSupportedTypes(?string $format): array
     {
-        return [AbsolutePercentValue::class => false];
+        return [AbsolutePercentValue::class => true];
     }
 }

--- a/tests/Normalizer/AbsolutePercentValueNormalizerTest.php
+++ b/tests/Normalizer/AbsolutePercentValueNormalizerTest.php
@@ -8,6 +8,7 @@ use AssoConnect\AbsolutePercentValueBundle\Normalizer\AbsolutePercentValueNormal
 use AssoConnect\AbsolutePercentValueBundle\Object\AbsolutePercentValue;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 
 class AbsolutePercentValueNormalizerTest extends TestCase
 {
@@ -26,12 +27,12 @@ class AbsolutePercentValueNormalizerTest extends TestCase
     }
 
     /**
-     * @param mixed $object
+     * @param mixed $data
      * @dataProvider providerSupportsNormalization
      */
-    public function testSupportsNormalization($object, bool $result): void
+    public function testSupportsNormalization($data, bool $result): void
     {
-        self::assertSame($result, $this->valueNormalizer->supportsNormalization($object));
+        self::assertSame($result, $this->valueNormalizer->supportsNormalization($data));
     }
 
     public function testNormalize(): void
@@ -67,7 +68,7 @@ class AbsolutePercentValueNormalizerTest extends TestCase
      */
     public function testDenormalizeFailure(mixed $data): void
     {
-        $this->expectException(NotNormalizableValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->valueNormalizer->denormalize($data, AbsolutePercentValue::class);
     }
 


### PR DESCRIPTION
Updates the AbsolutePercentValue normalizer to throw UnexpectedValueException instead of NotNormalizableValueException, providing more accurate exception handling.

Also, ensures that AbsolutePercentValue::class is a supported type for the normalizer.