### PR TITLE
Upgrade PHPUnit configuration to version 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require-dev": {
-        "assoconnect/php-quality-config": "^2"
+        "assoconnect/php-quality-config": "^2.2"
     },
     "require": {
         "php": "^8.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="main">
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
   <testsuites>
     <testsuite name="main">
       <directory>./tests/</directory>

--- a/src/Normalizer/AbsolutePercentValueNormalizer.php
+++ b/src/Normalizer/AbsolutePercentValueNormalizer.php
@@ -59,7 +59,7 @@ class AbsolutePercentValueNormalizer implements NormalizerInterface, Denormalize
         }
 
         try {
-            return new AbsolutePercentValue($data['type'], $data['value']);
+            return new AbsolutePercentValue($data['type'] ?? null, $data['value'] ?? null);
         } catch (Throwable $e) {
             throw new UnexpectedValueException(previous: $e);
         }


### PR DESCRIPTION
## Summary
- Updates `phpunit.xml.dist` to use PHPUnit 10 schema
- Moves source directory configuration from `<coverage>` to `<source>` (PHPUnit 10 format)
- Removes deprecated `processUncoveredFiles` attribute
- Fixes PHP warning in `AbsolutePercentValueNormalizer` when input array is missing `type` or `value` keys (PHPUnit 10 now captures and reports PHP warnings as test issues)

## Test plan
- [ ] All PHPUnit tests pass with no warnings or deprecations
- [ ] phpcs passes
- [ ] phpstan passes
- [ ] rector --dry-run passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)